### PR TITLE
26 switch output format

### DIFF
--- a/lib/stones-spec/example.rb
+++ b/lib/stones-spec/example.rb
@@ -54,10 +54,10 @@ module StonesSpec
     end
 
     def make_error_output(error_message, initial_board_gbb)
-      if language.is_syntax_error?(@result)
+      if language.syntax_error?(@result)
         raise GobstonesSyntaxError, error_message
       end
-      if language.is_runtime_error?(error_message)
+      if language.runtime_error?(error_message)
         "#{get_html_board 'Tablero inicial', initial_board_gbb, gobstones_command}\n#{error_message}"
       else
         error_message

--- a/lib/stones-spec/example.rb
+++ b/lib/stones-spec/example.rb
@@ -33,7 +33,7 @@ module StonesSpec
 
       if @status == :failed
         error_message = language.parse_error_message @result
-        return [self.title, make_error_output(error_message, initial_board_gbb), :failed]
+        return [with_header(self.title), make_error_output(error_message, initial_board_gbb), :failed]
       end
 
       @postcondition.validate(initial_board_gbb, @actual_final_board_file.read, language.parse_success_output(@result))
@@ -54,11 +54,17 @@ module StonesSpec
     end
 
     def make_error_output(error_message, initial_board_gbb)
-      if language.is_runtime_error?(@result)
+      if language.is_syntax_error?(@result)
+        raise GobstonesSyntaxError, error_message
+      end
+      if language.is_runtime_error?(error_message)
         "#{get_html_board 'Tablero inicial', initial_board_gbb, gobstones_command}\n#{error_message}"
       else
         error_message
       end
     end
+  end
+
+  class GobstonesSyntaxError < Exception
   end
 end

--- a/lib/stones-spec/example.rb
+++ b/lib/stones-spec/example.rb
@@ -33,7 +33,7 @@ module StonesSpec
 
       if @status == :failed
         error_message = language.parse_error_message @result
-        return [make_error_output(error_message, initial_board_gbb), :failed]
+        return [self.title, make_error_output(error_message, initial_board_gbb), :failed]
       end
 
       @postcondition.validate(initial_board_gbb, @actual_final_board_file.read, language.parse_success_output(@result))
@@ -55,7 +55,7 @@ module StonesSpec
 
     def make_error_output(error_message, initial_board_gbb)
       if language.is_runtime_error?(@result)
-        with_title self.title, "#{get_html_board 'Tablero inicial', initial_board_gbb, gobstones_command}\n#{error_message}"
+        "#{get_html_board 'Tablero inicial', initial_board_gbb, gobstones_command}\n#{error_message}"
       else
         error_message
       end

--- a/lib/stones-spec/language/gobstones.rb
+++ b/lib/stones-spec/language/gobstones.rb
@@ -28,6 +28,10 @@ module StonesSpec::Language
       result.include? 'Error en tiempo de ejecución'
     end
 
+    def self.is_syntax_error?(result)
+      result.include? 'Error de sintaxis' or result.include? 'Error en el programa'
+    end
+
     def self.parse_success_output(result)
       get_first_return_value result || ''
     end

--- a/lib/stones-spec/language/gobstones.rb
+++ b/lib/stones-spec/language/gobstones.rb
@@ -24,12 +24,12 @@ module StonesSpec::Language
       "<pre>#{ErrorMessageParser.new.parse(result)}</pre>"
     end
 
-    def self.is_runtime_error?(result)
+    def self.runtime_error?(result)
       result.include? 'Error en tiempo de ejecución'
     end
 
-    def self.is_syntax_error?(result)
-      result.include? 'Error de sintaxis' or result.include? 'Error en el programa'
+    def self.syntax_error?(result)
+      result.include_any? ['Error de sintaxis', 'Error en el programa']
     end
 
     def self.parse_success_output(result)

--- a/lib/stones-spec/language/ruby.rb
+++ b/lib/stones-spec/language/ruby.rb
@@ -16,12 +16,12 @@ module StonesSpec::Language
       "<pre>#{result}</pre>"
     end
 
-    def self.is_runtime_error?(result)
+    def self.runtime_error?(result)
       (result.include? 'OutOfBoardError') || !!(result =~ /(red|blue|green|black) Underflow/)
     end
 
-    def self.is_syntax_error?(result)
-      result.include? 'SyntaxError' or result.include? 'NameError'
+    def self.syntax_error?(result)
+      result.include_any? ['NameError', 'SyntaxError']
     end
 
     def self.parse_success_output(result)

--- a/lib/stones-spec/language/ruby.rb
+++ b/lib/stones-spec/language/ruby.rb
@@ -20,6 +20,10 @@ module StonesSpec::Language
       (result.include? 'OutOfBoardError') || !!(result =~ /(red|blue|green|black) Underflow/)
     end
 
+    def self.is_syntax_error?(result)
+      result.include? 'SyntaxError' or result.include? 'NameError'
+    end
+
     def self.parse_success_output(result)
       result
     end

--- a/lib/stones-spec/postcondition.rb
+++ b/lib/stones-spec/postcondition.rb
@@ -53,7 +53,7 @@ module StonesSpec
     def make_result(gbb_boards, status)
       boards = gbb_boards.map { |gbb_with_caption| get_html_board *gbb_with_caption, example.gobstones_command }.join("\n")
       output = "<div>#{boards}</div>"
-      [example.title, output, status]
+      [with_header(example.title), output, status]
     end
 
     def matches_with_expected_board?(actual_board)
@@ -80,9 +80,9 @@ module StonesSpec
       normalized_actual_return = actual_return.strip
 
       if normalized_actual_return == return_value
-        ['', :passed]
+        ['', '', :passed]
       else
-        ["Se esperaba <b>#{return_value}</b> pero se obtuvo <b>#{normalized_actual_return}</b>"]
+        ['', "Se esperaba <b>#{return_value}</b> pero se obtuvo <b>#{normalized_actual_return}</b>", :failed]
       end
     end
   end

--- a/lib/stones-spec/postcondition.rb
+++ b/lib/stones-spec/postcondition.rb
@@ -52,8 +52,8 @@ module StonesSpec
 
     def make_result(gbb_boards, status)
       boards = gbb_boards.map { |gbb_with_caption| get_html_board *gbb_with_caption, example.gobstones_command }.join("\n")
-      output = "<div>#{with_title example.title, boards}</div>"
-      [output, status]
+      output = "<div>#{boards}</div>"
+      [example.title, output, status]
     end
 
     def matches_with_expected_board?(actual_board)

--- a/lib/stones-spec/runner.rb
+++ b/lib/stones-spec/runner.rb
@@ -15,10 +15,9 @@ module StonesSpec
       check_head_position = test_definition[:check_head_position]
       show_initial_board = test_definition.fetch(:show_initial_board, true)
 
-      results = test_definition[:examples].map do |example_definition|
+      test_definition[:examples].map do |example_definition|
         run_example!(example_definition, check_head_position, show_initial_board, source, subject)
       end
-      aggregate_results(results)
     end
 
     private
@@ -36,10 +35,6 @@ module StonesSpec
       example.result
     ensure
       example.stop!
-    end
-
-    def aggregate_results(results)
-      [results.map { |it| it[0] }.join("\n<hr>\n"), results.all? { |it| it[1] == :passed } ? :passed : :failed]
     end
   end
 end

--- a/lib/stones-spec/runner.rb
+++ b/lib/stones-spec/runner.rb
@@ -20,7 +20,7 @@ module StonesSpec
           run_example!(example_definition, check_head_position, show_initial_board, source, subject)
         end
       rescue GobstonesSyntaxError => e
-        [e.message, :failed]
+        [e.message, :errored]
       end
     end
 

--- a/lib/stones-spec/runner.rb
+++ b/lib/stones-spec/runner.rb
@@ -15,8 +15,12 @@ module StonesSpec
       check_head_position = test_definition[:check_head_position]
       show_initial_board = test_definition.fetch(:show_initial_board, true)
 
-      test_definition[:examples].map do |example_definition|
-        run_example!(example_definition, check_head_position, show_initial_board, source, subject)
+      begin
+        test_definition[:examples].map do |example_definition|
+          run_example!(example_definition, check_head_position, show_initial_board, source, subject)
+        end
+      rescue GobstonesSyntaxError => e
+        [e.message, :failed]
       end
     end
 

--- a/lib/stones-spec/with_gbb_html_rendering.rb
+++ b/lib/stones-spec/with_gbb_html_rendering.rb
@@ -20,6 +20,14 @@ module StonesSpec
       end
     end
 
+    def with_header(title)
+      if title
+        "<h3>#{title}</h3>"
+      else
+        ''
+      end
+    end
+
     private
 
     def with_caption(caption, board_html)

--- a/spec/data/syntax_error_ruby.yml
+++ b/spec/data/syntax_error_ruby.yml
@@ -1,0 +1,15 @@
+:source: |
+  def main
+    @
+  end
+
+:examples:
+ - :initial_board: |
+     GBB/1.0
+     size 4 4
+     head 0 0
+   :final_board: |
+     GBB/1.0
+     size 4 4
+     head 0 0
+   :title: A syntax error

--- a/spec/gobstones_runner_spec.rb
+++ b/spec/gobstones_runner_spec.rb
@@ -175,7 +175,7 @@ Error en tiempo de ejecución:
       context 'when the file is not sintactically ok,' do
         let(:test_file) { 'syntax_error' }
 
-        it { expect(results[1]).to eql :failed }
+        it { expect(results[1]).to eql :errored }
         it do
           expect(results[0]).to eq(
 '<pre>cerca de un identificador con mayúscula "Error"

--- a/spec/gobstones_runner_spec.rb
+++ b/spec/gobstones_runner_spec.rb
@@ -14,48 +14,49 @@ describe Runner do
     let(:runner) { Runner.new(lang, command) }
     let(:test_definition) { YAML.load_file "spec/data/#{test_file}.yml" }
     let(:results) { runner.run! test_definition }
-    let(:html) { results[0] }
-    let(:status) { results[1] }
+    let(:all_htmls) { results.map { |it| it[1] } }
+    let(:html) { all_htmls[0] }
+    let(:title) { results.map { |it| it[0] } }
 
     describe 'procedure spec' do
       context 'when passes' do
         let(:test_file) { 'gobstones/procedure/move_to_origin_ok' }
-        it { expect(status).to eq :passed }
+        it { expect(all_examples :passed).to be true }
       end
 
       context 'when passes with arguments' do
         let(:test_file) { 'gobstones/procedure/times_move_ok' }
-        it { expect(status).to eq :passed }
+        it {expect(all_examples :passed).to be true }
       end
 
       context 'when fails' do
         let(:test_file) { 'gobstones/procedure/move_to_origin_fail' }
-        it { expect(status).to eq :failed }
+        it { expect(all_examples :failed).to be true }
       end
 
       context 'when fails with arguments' do
         let(:test_file) { 'gobstones/procedure/times_move_fail' }
-        it { expect(status).to eq :failed }
+        it { expect(all_examples :failed).to be true }
       end
 
       context 'when no title is given, it uses the procedure name and the arguments' do
         let(:test_file) { 'gobstones/procedure/times_move_ok' }
-        it { expect(html).to include '<h3>TimesMove(3, Sur)</h3>' }
-        it { expect(html).to include '<h3>TimesMove(2, Este)</h3>' }
+        it { expect(title).to include '<h3>TimesMove(3, Sur)</h3>' }
+        it { expect(title).to include '<h3>TimesMove(2, Este)</h3>' }
       end
     end
 
     describe 'function spec' do
       context 'when passes with args' do
         let(:test_file) { 'gobstones/function/remaining_cells_ok' }
-        it { expect(status).to eq :passed }
+        it {expect(all_examples :passed).to be true }
       end
 
       context 'when fails with args' do
         let(:test_file) { 'gobstones/function/remaining_cells_fail' }
 
-        it { expect(status).to eq :failed }
-        it { expect(html).to eq 'Se esperaba <b>9</b> pero se obtuvo <b>18</b>' }
+        it { expect(all_examples :failed).to be true }
+        it { expect(html).to include 'Se esperaba <b>9</b> pero se obtuvo <b>18</b>' }
       end
     end
 
@@ -68,52 +69,52 @@ describe Runner do
       context 'can check head position' do
         context 'when its wrong' do
           let(:test_file) { 'head_position_wrong' }
-          it { expect(status).to eq(:failed) }
+          it { expect(all_examples :failed).to be true }
         end
 
         context 'when its ok' do
           let(:test_file) { 'head_position_ok' }
-          it { expect(status).to eq(:passed) }
+          it { expect(all_examples :passed).to be true }
         end
       end
 
       context 'when a title is given' do
         context 'and the test passes' do
           let(:test_file) { 'red_ball_at_origin' }
-          it { expect(html).to include '<h3>A red ball</h3>' }
+          it { expect(title).to include '<h3>A red ball</h3>' }
         end
 
         context 'and the test fails' do
           let(:test_file) { 'red_ball_at_origin_wrong' }
-          it { expect(html).to include '<h3>A red ball</h3>' }
+          it { expect(title).to include '<h3>A red ball</h3>' }
         end
 
         context 'and syntax errors are present' do
           let(:test_file) { 'syntax_error' }
-          it { expect(html).not_to include '<h3>A syntax error</h3>' }
+          it { expect(title).not_to include '<h3>A syntax error</h3>' }
         end
 
         context 'and a runtime error occurs' do
           let(:test_file) { 'runtime_error' }
-          it { expect(html).to include '<h3>A runtime error</h3>' }
+          it { expect(title).to include '<h3>A runtime error</h3>' }
         end
       end
 
       context 'when a title is not given' do
         context 'and the test passes' do
           let(:test_file) { 'red_ball_at_origin_without_title' }
-          it { expect(html).not_to include '<h3></h3>' }
+          it { expect(title).not_to include '<h3></h3>' }
         end
 
         context 'and a runtime error occurs' do
           let(:test_file) { 'runtime_error_without_title' }
-          it { expect(html).not_to include '<h3></h3>' }
+          it { expect(title).not_to include '<h3></h3>' }
         end
       end
 
       context 'doesnt check head position if the flag is false' do
         let(:test_file) { 'dont_check_head_position' }
-        it { expect(status).to eq(:passed) }
+        it { expect(all_examples :passed).to be true }
       end
 
       context 'doesnt include the initial board if the flag is false' do
@@ -125,7 +126,7 @@ describe Runner do
         context 'when the final board matches' do
           let(:test_file) { 'red_ball_at_origin' }
 
-          it { expect(status).to eq(:passed) }
+          it { expect(all_examples :passed).to be true }
 
           context 'should return an html representation of the initial and final board as result' do
             it { expect(html).to include(File.new('spec/data/red_ball_at_origin_initial.html').read) }
@@ -137,7 +138,7 @@ describe Runner do
 
         context 'when the final board doesnt match' do
           let(:test_file) { 'red_ball_at_origin_wrong' }
-          it { expect(status).to eq(:failed) }
+          it { expect(all_examples :failed).to be true }
 
           context 'should return an html representation of the initial, expected and actual boards as result' do
             it { expect(html).to include(File.new('spec/data/red_ball_at_origin_initial.html').read) }
@@ -151,11 +152,11 @@ describe Runner do
         context 'when produces BOOM' do
           let(:test_file) { 'runtime_error' }
 
-          it { expect(status).to eq(:failed) }
+          it { expect(all_examples :failed).to be true }
 
-          it { expect(html).to include(File.new('spec/data/runtime_error_initial.html').read) }
+          it { expect(all_htmls.join("\n")).to include(File.new('spec/data/runtime_error_initial.html').read) }
           it do
-            expect(html).to include(
+            expect(all_htmls.join("\n")).to include(
 '<pre>cerca de invocación a procedimiento
   |
   V
@@ -174,9 +175,9 @@ Error en tiempo de ejecución:
       context 'when the file is not sintactically ok,' do
         let(:test_file) { 'syntax_error' }
 
-        it { expect(status).to eq(:failed) }
+        it { expect(results[1]).to eql :failed }
         it do
-          expect(html).to eq(
+          expect(results[0]).to eq(
 '<pre>cerca de un identificador con mayúscula "Error"
         |
         V
@@ -191,4 +192,9 @@ Error en el programa:
       end
     end
   end
+
+  def all_examples status
+    results.all? {|result| result[2].eql? status}
+  end
+
 end

--- a/spec/ruby_runnner_spec.rb
+++ b/spec/ruby_runnner_spec.rb
@@ -103,7 +103,7 @@ describe Language::Ruby do
     context 'when the file is not sintactically ok' do
       context 'should return an unstructured output' do
         let(:results) { runner.run!(YAML.load_file 'spec/data/syntax_error_ruby.yml') }
-        it { expect(results[1]).to eql :failed }
+        it { expect(results[1]).to eql :errored }
         it { expect(results[0]).to include 'SyntaxError' }
       end
     end

--- a/spec/ruby_runnner_spec.rb
+++ b/spec/ruby_runnner_spec.rb
@@ -14,7 +14,7 @@ describe Language::Ruby do
   let(:lang) { Language::Ruby }
   let(:command) { 'python .heroku/vendor/pygobstones-lang/pygobstoneslang.py' }
   let(:runner) { Runner.new(lang, command) }
-  let(:html) { results[0] }
+  let(:html) { results[0][1] }
 
 
   describe 'procedure spec' do
@@ -47,14 +47,14 @@ describe Language::Ruby do
     context 'when passes with args' do
       let(:results) { runner.run!(YAML.load_file 'spec/data/ruby/function/remaining_cells_ok.yml') }
 
-      it {expect(results ).to eq :passed }
+      it {expect(all_examples :passed).to be true }
     end
 
     context 'when fails with args' do
       let(:results) { runner.run!(YAML.load_file 'spec/data/ruby/function/remaining_cells_fail.yml') }
 
-      it { expect(all_examples :failed).to be true }
-      it { expect(results[0]).to eq 'Se esperaba <b>9</b> pero se obtuvo <b>18</b>' }
+      it { expect(results[0][2] ).to eq :failed }
+      it { expect(html).to eq 'Se esperaba <b>9</b> pero se obtuvo <b>18</b>' }
     end
   end
 
@@ -98,6 +98,13 @@ describe Language::Ruby do
           it { expect(html).to start_with('<div>') }
           it { expect(html).to end_with('</div>') }
         end
+      end
+    end
+    context 'when the file is not sintactically ok' do
+      context 'should return an unstructured output' do
+        let(:results) { runner.run!(YAML.load_file 'spec/data/syntax_error_ruby.yml') }
+        it { expect(results[1]).to eql :failed }
+        it { expect(results[0]).to include 'SyntaxError' }
       end
     end
   end

--- a/spec/ruby_runnner_spec.rb
+++ b/spec/ruby_runnner_spec.rb
@@ -21,25 +21,25 @@ describe Language::Ruby do
     context 'when passes' do
       let(:results) { runner.run!(YAML.load_file 'spec/data/ruby/procedure/move_to_origin_ok.yml') }
 
-      it { expect(results[1]).to eq :passed }
+      it { expect(all_examples :passed).to be true }
     end
 
     context 'when passes with arguments' do
       let(:results) { runner.run!(YAML.load_file 'spec/data/ruby/procedure/times_move_ok.yml') }
 
-      it { expect(results[1]).to eq :passed }
+      it { expect(all_examples :passed).to be true }
     end
 
     context 'when fails' do
       let(:results) { runner.run!(YAML.load_file 'spec/data/ruby/procedure/move_to_origin_fail.yml') }
 
-      it { expect(results[1]).to eq :failed }
+      it { expect(all_examples :failed).to be true  }
     end
 
     context 'when fails with arguments' do
       let(:results) { runner.run!(YAML.load_file 'spec/data/ruby/procedure/times_move_fail.yml') }
 
-      it { expect(results[1]).to eq :failed }
+      it { expect(all_examples :failed).to be true }
     end
   end
 
@@ -47,13 +47,13 @@ describe Language::Ruby do
     context 'when passes with args' do
       let(:results) { runner.run!(YAML.load_file 'spec/data/ruby/function/remaining_cells_ok.yml') }
 
-      it { expect(results[1]).to eq :passed }
+      it {expect(results ).to eq :passed }
     end
 
     context 'when fails with args' do
       let(:results) { runner.run!(YAML.load_file 'spec/data/ruby/function/remaining_cells_fail.yml') }
 
-      it { expect(results[1]).to eq :failed }
+      it { expect(all_examples :failed).to be true }
       it { expect(results[0]).to eq 'Se esperaba <b>9</b> pero se obtuvo <b>18</b>' }
     end
   end
@@ -61,7 +61,7 @@ describe Language::Ruby do
   context 'when its ok' do
     let(:results) { runner.run!(YAML.load_file 'spec/data/head_position_ok_ruby.yml') }
 
-    it { expect(results[1]).to eq(:passed) }
+    it { expect(all_examples :passed).to be true }
 
     it { expect(html).to start_with('<div>') }
     it { expect(html).to end_with('</div>') }
@@ -71,7 +71,7 @@ describe Language::Ruby do
     context 'when head falls out of board' do
       let(:results) { runner.run!(YAML.load_file 'spec/data/runtime_error_ruby.yml') }
 
-      it { expect(results[1]).to eq(:failed) }
+      it { expect(all_examples :failed).to be true }
 
       it { expect(html).to include(File.new('spec/data/runtime_error_initial.html').read) }
       it { expect(html).to end_with('</pre>') }
@@ -80,7 +80,7 @@ describe Language::Ruby do
     context 'when no stones are available for popping' do
       let(:results) { runner.run!(YAML.load_file 'spec/data/runtime_error_pop_ruby.yml') }
 
-      it { expect(results[1]).to eq(:failed) }
+      it { expect(all_examples :failed).to be true }
 
       it { expect(html).to include(File.new('spec/data/runtime_error_initial.html').read) }
       it { expect(html).to end_with('</pre>') }
@@ -90,7 +90,7 @@ describe Language::Ruby do
       context 'when the final board matches' do
         let(:results) { runner.run!(YAML.load_file 'spec/data/red_ball_at_origin_ruby.yml') }
 
-        it { expect(results[1]).to eq(:passed) }
+        it { expect(all_examples :passed).to be true }
 
         context 'should return an html representation of the initial and final board as result' do
           it { expect(html).to include(File.new('spec/data/red_ball_at_origin_initial.html').read) }
@@ -100,5 +100,9 @@ describe Language::Ruby do
         end
       end
     end
+  end
+
+  def all_examples status
+    results.all? {|result| result[2].eql? status}
   end
 end


### PR DESCRIPTION
Fixes #26 #24 

Switched output to the new structured output format.

Now, when a syntax error ocurrs, it raises an exception to prevent other examples to be executed, and returns the old unstructured output with the error description (only once).
